### PR TITLE
There should be no preference related to declaration of several vars

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -131,21 +131,25 @@ var foo = {
 
 All variables should **always** be declared using `var`. There are **no** exceptions to this rule!
 
-If possible declare several variables using the same var statement.
 BAD:
 
 ```lang=js
 var var1 = true;
-var var2 = false;
-var var3;
+var2 = false;
 ```
 
 GOOD:
 
 ```lang=js
 var var1 = true,
-    var2 = false,
-    var3;
+    var2 = false;
+```
+
+OR:
+
+```lang=js
+var var1 = true;
+var var2 = false;
 ```
 
 ## Strings ##


### PR DESCRIPTION
There should be no preference on whether we declare several variables in the same var statement.
I think this matters very little, and can be left to personal preference. 

Using the var statement for each variable makes it easier to move the statement around or removing it. So I think a case also could be made for changing the rule so that one has to use a var statement for every variable. 

Thoughts?
