### PR TITLE
Update README to use coding standard in example

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -87,7 +87,8 @@ Every function, including object methods, must have a docblock that contains at 
  * @throws Some_Exception If something interesting cannot happen
  * @return boolean
  */
-function doesSomethingInteresting(Place $where, $repeat = 1) {
+function doesSomethingInteresting(Place $where, $repeat = 1)
+{
     // Implementation
 }
 ```


### PR DESCRIPTION
Opening braces for methods MUST go on the next line
