### PR TITLE
Add exception for JSON global

### DIFF
--- a/javascript/.jshintrc
+++ b/javascript/.jshintrc
@@ -28,6 +28,8 @@
         "before"     : false,
         "beforeEach" : false,
         "after"      : false,
-        "afterEach"  : false
+        "afterEach"  : false,
+        /* Allow JSON global even if IE7 doesn't support it (see "es3" option) */
+        "JSON": false
     }
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgno-coding-standards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "VG.no coding standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since we're using the `es3` to prevent using keywords in IE8 and whatnot, JSHint now reports `JSON` as being an undefined global. Since our lowest denominator currently is set on IE8, and IE8 supports JSON natively, I think we should allow using `JSON.parse()` and `JSON.stringify()` without shims.
