### PR TITLE
Allow using hoisted functions

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -116,7 +116,7 @@
         "no-unreachable": 2,
         "no-unused-expressions": 2,
         "no-unused-vars": 2,
-        "no-use-before-define": 2,
+        "no-use-before-define": [2, "nofunc"],
         "no-void": 2,
         "no-warning-comments": 1,
         "no-with": 2,

--- a/javascript/.eslintrc-react
+++ b/javascript/.eslintrc-react
@@ -122,7 +122,7 @@
         "no-unreachable": 2,
         "no-unused-expressions": 2,
         "no-unused-vars": 2,
-        "no-use-before-define": 2,
+        "no-use-before-define": [2, "nofunc"],
         "no-void": 2,
         "no-warning-comments": 1,
         "no-with": 2,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vgno-coding-standards",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "VG.no coding standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The ESLint configuration disallows hoisted variables, but hoisting functions **should** be allowed (JSHint configuration already allows this).
