### PR TITLE
Add max line length rule (120 chars)

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -25,7 +25,7 @@
         "indent": 2,
         "key-spacing": 2,
         "max-depth": [2, 6],
-        "max-len": 0,
+        "max-len": [2, 120, 4],
         "max-nested-callbacks": [2, 6],
         "max-params": 0,
         "max-statements": 0,


### PR DESCRIPTION
The coding standard defines a max line length of 120 characters, but the eslint configuration does not enforce it. This PR adds it to the configuration.
