### PR TITLE
Enforce max empty lines

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -76,7 +76,7 @@
         "no-mixed-spaces-and-tabs": 2,
         "no-multi-spaces": 2,
         "no-multi-str": 2,
-        "no-multiple-empty-lines": 2,
+        "no-multiple-empty-lines": [2, {"max": 1}],
         "no-native-reassign": 2,
         "no-negated-in-lhs": 2,
         "no-nested-ternary": 2,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "vgno-coding-standards",
-  "version": "1.0.5",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "version": "1.0.6",
   "description": "VG.no coding standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Seems like the default for this rule is 4 empty lines, which I think is excessive. This new rule matches our JSCS configuration.
