### PR TITLE
Enforce consistent prop quoting

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -122,7 +122,7 @@
         "one-var": 0,
         "operator-assignment": [2, "always"],
         "padded-blocks": [2, "never"],
-        "quote-props": [2,  "as-needed", { "keywords": true }],
+        "quote-props": [2,  "consistent-as-needed"],
         "quotes": [2, "single"],
         "radix": 2,
         "semi": 2,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.0.8",
+  "version": "2.0.0",
   "description": "VG.no coding standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
_Lets try that again_

I propose that we change the prop quoting rules.

Right now, this will error:

``` js
{
    'foo': 'bar',
    '1player': 'yes'
}
```

Because the prop `foo` does not _need_ quotes. I however think it's much tidier that we keep it consistent within the same object. With this proposed change, the above would be valid, but the following would error:

``` js
{
    foo: 'bar',
    '1player': 'yes'
}
```

Additionally, (like now) the following is of course legal:

``` js
{
    foo: 'bar',
    bar: 'baz'
}
```

Please :+1: or :-1:.
@androa ?
@voldern ?
@andreasrs ?
@kbrabrand ?
