### PR TITLE
Require indented switch cases

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -22,7 +22,7 @@
         "func-names": 0,
         "func-style": 0,
         "handle-callback-err": 2,
-        "indent": 2,
+        "indent": [2, 4, {"SwitchCase": 1}],
         "key-spacing": 2,
         "max-depth": [2, 6],
         "max-len": [2, 120, 4],

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "VG.no coding standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Our coding standard says:

The switch statement should be written as in the example:

``` javascript
switch (value) {
    case 1:
        // ...
        break;

    case 2:
        // ...
        break;

    default:
        // ...
        // no break keyword on the last case
}
```

The ESLint configuration does not match this, currently. It requires the `case`s to be on the same level as the `switch`. This PR changes that to be in accordance with the coding standard.
