### PR TITLE
Support both IIFE wrapping styles

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -146,7 +146,7 @@
         }],
         "valid-typeof": 2,
         "vars-on-top": 0,
-        "wrap-iife": 2,
+        "wrap-iife": [2, "any"],
         "wrap-regex": 0,
         "yoda": 2
     }


### PR DESCRIPTION
With the current configuration we have to wrap the IIFE like this:

``` javascript
((function() {}());
```

I want to be able to do like this as well

``` javascript
(function() {})();
```
