### PR TITLE
replaced deprecated react/jsx-quotes -> jsx-quotes

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -23,6 +23,7 @@
         "func-style": 0,
         "handle-callback-err": 2,
         "indent": [2, 4, {"SwitchCase": 1}],
+        "jsx-quotes": [2, "prefer-double"],
         "key-spacing": 2,
         "max-depth": [2, 6],
         "max-len": [2, 120, 4],

--- a/javascript/.eslintrc-react
+++ b/javascript/.eslintrc-react
@@ -8,7 +8,6 @@
     },
     "rules": {
         "react/jsx-boolean-value": 2,
-        "react/jsx-quotes": [2, "double", "avoid-escape"],
         "react/jsx-no-undef": 2,
         "react/jsx-sort-props": 0,
         "react/jsx-uses-react": 2,


### PR DESCRIPTION
Replaced regarding to deprecation notice https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md
