### PR TITLE
Allow undefined

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -110,7 +110,7 @@
         "no-trailing-spaces": 2,
         "no-undef": 2,
         "no-undef-init": 2,
-        "no-undefined": 2,
+        "no-undefined": 0,
         "no-underscore-dangle": 2,
         "no-unreachable": 2,
         "no-unused-expressions": 2,


### PR DESCRIPTION
Allow use of `undefined` to be compatible with our coding standards.

Our coding standards state that checking if a variable is defined should be carried out in the following way:

```
x === undefined
```

Another use case for `undefined` is skipping optional parameters in function invocations.

Discussion: https://github.com/vgno/coding-standards/commit/87a109a7564536a79c9f66d7e4b1f5b385b4a5dd#commitcomment-13444176
