### PR TITLE
Fix some rules related to eslint-plugin-react 6.0 and bump major

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -126,7 +126,6 @@
         "quote-props": [2,  "consistent-as-needed"],
         "quotes": [2, "single"],
         "radix": 2,
-        "require-yield": 2,
         "semi": 2,
         "semi-spacing": 2,
         "sort-vars": 0,

--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -126,6 +126,7 @@
         "quote-props": [2,  "consistent-as-needed"],
         "quotes": [2, "single"],
         "radix": 2,
+        "require-yield": 2,
         "semi": 2,
         "semi-spacing": 2,
         "sort-vars": 0,

--- a/javascript/.eslintrc-react
+++ b/javascript/.eslintrc-react
@@ -21,6 +21,6 @@
         "react/prop-types": 2,
         "react/react-in-jsx-scope": 2,
         "react/self-closing-comp": 2,
-        "react/wrap-multilines": 2
+        "react/jsx-wrap-multilines": 2
     }
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "VG.no coding standards",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This will rename 1 rule for react configuration, so it's compatible with new major for `eslint-plugin-react` (see: https://github.com/yannickcr/eslint-plugin-react/releases/tag/v6.0.0)

The major bump is mostly in order to have the same version in here and in https://github.com/vgno/eslint-config-vgno
Which we want to bump major also to move to eslint v3.0 and eslint-plugin-react v6.0
