### PR TITLE
Update link to Google Java Code Style

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,6 +1,6 @@
 # General
 
-We follow the [Google Java Code Style](https://google-styleguide.googlecode.com/svn/trunk/javaguide.html), with some exceptions:
+We follow the [Google Java Code Style](https://google.github.io/styleguide/javaguide.html), with some exceptions:
 
 **3.3.1** Wildcard imports are allowed in unit tests
 


### PR DESCRIPTION
The old link (https://google-styleguide.googlecode.com/svn/trunk/javaguide.html) no longer works. Please check that the new link refers to the correct document